### PR TITLE
fix: forecast always repeats current condition (#46)

### DIFF
--- a/custom_components/micro_weather/analysis/trends.py
+++ b/custom_components/micro_weather/analysis/trends.py
@@ -322,15 +322,70 @@ class TrendsAnalyzer:
         return correlations
 
     def analyze_pressure_trends(self, altitude: float = 0.0) -> Dict[str, Any]:
-        """Analyze historical pressure trends.
+        """Analyze historical pressure trends and classify the system.
+
+        The forecast engine (evolution lifecycle, daily/hourly generators)
+        consumes ``current_trend``, ``long_term_trend``, ``pressure_system``
+        and ``storm_probability``.  Those keys must be produced here -- if
+        they are absent, downstream validation silently defaults them to 0,
+        which collapses every forecast lifecycle to a single "stable" phase
+        and makes the whole forecast repeat the current condition (see #46).
+
+        Pressure history is stored in inHg, but the trend thresholds and storm
+        heuristics are expressed in hPa, so the per-hour regression slope is
+        converted to a 3-hour / 24-hour change in hPa.
 
         Args:
             altitude: Altitude in meters (for future pressure correction)
 
         Returns:
-            Dictionary with pressure trend analysis
+            Dictionary with the raw trend statistics plus the classification
+            keys, or an empty dict when there is insufficient history.
         """
-        return self.get_historical_trends("pressure", hours=24)
+        from ..weather_utils import convert_to_hpa
+
+        long_trend = self.get_historical_trends("pressure", hours=24)
+        if not long_trend:
+            return {}
+
+        # Short-term (3h) slope drives current_trend; fall back to the 24h
+        # slope if there is not yet a distinct 3h window of data.
+        short_trend = self.get_historical_trends("pressure", hours=3)
+        short_slope = (
+            short_trend.get("trend", 0.0) if short_trend else long_trend["trend"]
+        )
+        long_slope = long_trend["trend"]
+
+        # inHg/hour slope -> pressure change in hPa over 3h / 24h.
+        current_trend = convert_to_hpa(short_slope * 3.0) or 0.0
+        long_term_trend = convert_to_hpa(long_slope * 24.0) or 0.0
+        current_pressure_hpa = convert_to_hpa(long_trend["current"]) or 1013.25
+
+        # Classify the pressure system by absolute pressure (hPa).
+        if current_pressure_hpa > 1020:
+            pressure_system = "high_pressure"
+        elif current_pressure_hpa < 1000:
+            pressure_system = "low_pressure"
+        else:
+            pressure_system = "normal"
+
+        # Storm probability from falling-pressure heuristics.
+        storm_probability = 0.0
+        if current_trend < -2.0:  # falling > 2 hPa in 3h
+            storm_probability += 40.0
+        if long_term_trend < -5.0:  # falling > 5 hPa in 24h
+            storm_probability += 30.0
+        if current_pressure_hpa < 990:  # deep low
+            storm_probability += 30.0
+        storm_probability = min(100.0, storm_probability)
+
+        return {
+            **long_trend,
+            "current_trend": current_trend,
+            "long_term_trend": long_term_trend,
+            "pressure_system": pressure_system,
+            "storm_probability": storm_probability,
+        }
 
     def compute_pressure_acceleration(self) -> float:
         """Compute pressure trend acceleration from the last 24h of readings.

--- a/custom_components/micro_weather/forecast/daily.py
+++ b/custom_components/micro_weather/forecast/daily.py
@@ -208,9 +208,18 @@ class DailyForecastGenerator:
         Returns:
             float: Forecasted temperature in °F
         """
-        # Get temperature trend from historical data (°F per hour)
+        # Get temperature trend from historical data (°F per hour).
+        # analyze_historical_patterns() emits patterns["temperature"] without a
+        # per-hour "trend" key (only volatility/trend_strength/seasonal_factor),
+        # so fall back to the 24h temperature slope carried in
+        # meteorological_state["temp_trends"].  Without this fallback the trend
+        # is always 0 and the day-0 high collapses to the current temp (#35).
         temp_pattern = historical_patterns.get(KEY_TEMPERATURE, {})
-        temp_trend_per_hour = temp_pattern.get("trend", 0)
+        temp_trend_per_hour = temp_pattern.get("trend")
+        if not isinstance(temp_trend_per_hour, (int, float)):
+            temp_trend_per_hour = meteorological_state.get("temp_trends", {}).get(
+                "trend", 0
+            )
         if not isinstance(temp_trend_per_hour, (int, float)):
             temp_trend_per_hour = 0.0
 
@@ -235,11 +244,14 @@ class DailyForecastGenerator:
                 hourly_estimates = [
                     current_temp + temp_trend_per_hour * h for h in range(1, 24)
                 ]
-                hourly_max = (
-                    max(hourly_estimates + [current_temp])
-                    if hourly_estimates
-                    else forecast_temp
-                )
+                candidates = hourly_estimates + [current_temp]
+                # Floor the day-0 high at the recent diurnal peak (the observed
+                # 24h max), so a cool morning/overnight reading does not report
+                # the current temp as the day's high (#35).
+                recent_max = meteorological_state.get("temp_trends", {}).get("max")
+                if isinstance(recent_max, (int, float)):
+                    candidates.append(recent_max)
+                hourly_max = max(candidates) if candidates else forecast_temp
                 forecast_temp = max(forecast_temp, hourly_max)
             except Exception as exc:
                 _LOGGER.debug(

--- a/tests/test_analysis_trends.py
+++ b/tests/test_analysis_trends.py
@@ -213,3 +213,54 @@ class TestTrendsAnalyzer:
         """Returns 0.0 when no pressure history exists."""
         analyzer = TrendsAnalyzer({})
         assert analyzer.compute_pressure_acceleration() == 0.0
+
+    def test_analyze_pressure_trends_emits_classification_keys(self):
+        """Regression for #46: forecast engine reads current_trend /
+        long_term_trend / storm_probability / pressure_system, so
+        analyze_pressure_trends() must produce them (not only the raw
+        get_historical_trends statistics).
+        """
+        history = {"pressure": deque(maxlen=192)}
+        base_time = datetime.now()
+        # Steadily falling pressure: ~ -0.02 inHg/hour over 24h.
+        # History is stored oldest-first; the newest reading is the lowest.
+        for hours_ago in range(23, -1, -1):
+            history["pressure"].append(
+                {
+                    "timestamp": base_time - timedelta(hours=hours_ago),
+                    "value": 29.50 + hours_ago * 0.02,
+                }
+            )
+        analyzer = TrendsAnalyzer(history)
+        result = analyzer.analyze_pressure_trends()
+
+        for key in (
+            "current_trend",
+            "long_term_trend",
+            "pressure_system",
+            "storm_probability",
+        ):
+            assert key in result, f"missing classification key: {key}"
+
+        # Falling pressure -> negative 3h and 24h change (in hPa).
+        assert result["current_trend"] < 0
+        assert result["long_term_trend"] < 0
+        # ~ -0.02 inHg/h * 3h * 33.8639 ~= -2 hPa/3h
+        assert -4.0 < result["current_trend"] < -1.0
+        # Sustained fall + low pressure raises storm probability above zero.
+        assert result["storm_probability"] > 0
+        assert result["pressure_system"] == "low_pressure"
+
+    def test_analyze_pressure_trends_stable_is_near_zero(self):
+        """Flat pressure yields a ~zero current_trend so the lifecycle
+        engine correctly treats conditions as stable (no false fronts)."""
+        history = {"pressure": deque(maxlen=192)}
+        base_time = datetime.now()
+        for i in range(24):
+            history["pressure"].append(
+                {"timestamp": base_time - timedelta(hours=i), "value": 30.00}
+            )
+        analyzer = TrendsAnalyzer(history)
+        result = analyzer.analyze_pressure_trends()
+        assert abs(result["current_trend"]) < 0.2
+        assert result["storm_probability"] == 0

--- a/tests/test_forecast_daily.py
+++ b/tests/test_forecast_daily.py
@@ -1165,6 +1165,61 @@ class TestIssue35BugFixes:
             result == expected_max
         ), f"Day-0 temp ({result}) should equal max of hourly estimates + current ({expected_max})"
 
+    def test_day0_max_reflects_diurnal_peak_with_production_patterns(
+        self, daily_forecast_generator
+    ):
+        """Regression for #35 CASE 1: the day-0 high must not collapse to the
+        current temperature.
+
+        In production, ``analyze_historical_patterns()`` emits
+        ``patterns['temperature'] = {volatility, trend_strength, seasonal_factor}``
+        with **no** inner ``"trend"`` key, so the old code read a default of 0
+        and the day-0 high always equalled the current temperature. The day-0
+        high must instead reflect the recent diurnal peak (24h observed max)
+        and the real 24h trend available in ``meteorological_state``.
+        """
+        current_temp = 60.0  # cool morning reading
+        meteorological_state = {
+            "pressure_analysis": {
+                "pressure_system": "normal",
+                "current_trend": 0.0,
+                "long_term_trend": 0.0,
+            },
+            "atmospheric_stability": 0.7,
+            # As produced by get_historical_trends("outdoor_temp", hours=24)
+            "temp_trends": {
+                "current": 60.0,
+                "average": 67.0,
+                "trend": 0.2,
+                "min": 58.0,
+                "max": 75.0,
+                "volatility": 5.0,
+            },
+        }
+        # Exactly the shape analyze_historical_patterns() emits (no "trend").
+        historical_patterns = {
+            "temperature": {
+                "volatility": 5.0,
+                "trend_strength": 0.2,
+                "seasonal_factor": 0.5,
+            },
+            "temperature_trend": 0.2,
+        }
+        system_evolution = {"confidence_levels": [0.8, 0.6, 0.7]}
+
+        result = daily_forecast_generator.forecast_temperature(
+            0,
+            current_temp,
+            meteorological_state,
+            historical_patterns,
+            system_evolution,
+        )
+
+        assert result >= 74.0, (
+            f"Day-0 high ({result}) should reflect the recent diurnal peak "
+            f"(~75°F), not collapse to the current temperature (60°F)"
+        )
+
     def test_daily_forecast_day_night_conversion_applied(
         self, daily_forecast_generator
     ):


### PR DESCRIPTION
## Summary

Fixes #46 — the daily and hourly forecast repeated the current weather for every period, regardless of pressure history.

## Root cause

The v4.3.0 lifecycle forecast engine reads four keys off `pressure_analysis`:
`current_trend`, `long_term_trend`, `pressure_system`, `storm_probability`.

But **nothing produced them.** `TrendsAnalyzer.analyze_pressure_trends()` only returned the raw `get_historical_trends()` statistics (`current/average/trend/min/max/volatility`) — there is no `current_trend` in that dict.

`forecast/meteorological.py` then "validates" the missing keys and **silently defaults them to 0**:

```python
for key in ["current_trend", "long_term_trend", "storm_probability"]:
    value = pressure_analysis.get(key)   # None — key never existed
    if not isinstance(value, (int, float)):
        pressure_analysis[key] = 0       # forced to zero
```

With `current_trend` permanently 0, `compute_lifecycle()` always takes the stable branch (`abs(0) < STABLE_THRESHOLD`) and returns a **single 120-hour phase** using the current condition. Every hourly slot resolves to that one phase, and the daily generator collapses the same way — so the whole forecast repeats the current weather. The computed pressure trend existed all along under the key `trend`, but was never read.

## Fix

Restore production of the classification keys in `analyze_pressure_trends()`:
- `current_trend` — 3-hour pressure change
- `long_term_trend` — 24-hour pressure change
- `pressure_system` — high/normal/low classification
- `storm_probability` — falling-pressure heuristic

Pressure history is stored in **inHg**, but the thresholds and storm heuristics are **hPa**-based (inherited from the original pre-refactor design — system thresholds at 1020/1000/990 hPa, storm rules at −2 hPa/3h and −5 hPa/24h). The per-hour slope is therefore converted inHg→hPa. Raw statistics and the empty-dict-on-no-data behaviour are preserved, so existing consumers and tests are unaffected.

## Tests

- Added regression tests in `test_analysis_trends.py` (fail on `main` with `KeyError: current_trend`, pass here).
- Full analysis/forecast/detector/validation suites pass (158 tests), including the CI-gated `test_weather_detector.py` and `test_validation.py`.
- black / isort / flake8 clean (pre-commit passed).

## Out of scope (separate from this regression)

- `compute_pressure_acceleration()` still returns inHg units while the trend is now hPa; it only nudges phase durations. Worth a follow-up, along with correcting the misleading `# (inHg/3h)` comment on `PressureTrendConstants`.
- The thread also mentions "current weather changes infrequently" (detection side) and "wind speed/gust not monitored" — those are unrelated to this forecast root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also fixes #35 CASE 1 (day-0 max temp == current temp)

Same class of bug, different key. `DailyForecastGenerator.forecast_temperature()` read the per-hour temperature trend from `historical_patterns["temperature"]["trend"]`, but `analyze_historical_patterns()` never emits that inner key (it produces `volatility` / `trend_strength` / `seasonal_factor`). The lookup defaulted to 0, so the day-0 hourly-max projection collapsed to the current temperature.

Fix:
- Fall back to the 24h temperature slope in `meteorological_state["temp_trends"]` when the per-hour pattern trend is absent.
- Floor the day-0 high at the recent diurnal peak (observed 24h max), so a cool morning/overnight reading no longer reports the current temp as the day's high.
- Adds a regression test using the real `analyze_historical_patterns()` / `temp_trends` shape (the existing day-0 tests used a hand-crafted shape production never produces, which masked the bug).

**Not** covered here: #35 CASE 2 ("always cloudy at night") was already addressed by an earlier fix; this PR's pressure-key fix additionally stops the multi-day forecast from flipping wholesale at sunset when pressure is actively trending.
